### PR TITLE
Add basic GUI editor

### DIFF
--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -78,6 +78,7 @@ try {
         `usage: observable <command>
   create       create a new app from a template
   preview      start the preview server
+  gui          start the GUI editor
   build        generate a static site
   login        sign-in to Observable
   logout       sign-out of Observable
@@ -190,6 +191,36 @@ try {
           hostname: host!,
           port: port === undefined ? undefined : +port,
           origins: cors ? ["*"] : origins,
+          open
+        })
+      );
+      break;
+    }
+    case "gui": {
+      const {values} = helpArgs(command, {
+        options: {
+          host: {
+            type: "string",
+            default: "127.0.0.1",
+            description: "the server host; use 0.0.0.0 to accept external connections"
+          },
+          port: {
+            type: "string",
+            description: "the server port; defaults to 3001 (or higher if unavailable)"
+          },
+          open: {
+            type: "boolean",
+            default: true,
+            description: "open browser"
+          },
+          "no-open": {type: "boolean"}
+        }
+      });
+      const {host, port, open} = values;
+      await import("../gui/server.js").then(async (gui) =>
+        gui.startGuiServer({
+          hostname: host!,
+          port: port === undefined ? undefined : +port,
           open
         })
       );

--- a/src/gui/App.tsx
+++ b/src/gui/App.tsx
@@ -1,0 +1,5 @@
+import React from "npm:react";
+
+export default function App() {
+  return <div>Observable GUI editor (work in progress)</div>;
+}

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Observable GUI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/src/gui/index.tsx
+++ b/src/gui/index.tsx
@@ -1,0 +1,8 @@
+import {createRoot} from "npm:react-dom";
+import React from "npm:react";
+import App from "./App.js";
+
+const container = document.getElementById("root");
+if (container) {
+  createRoot(container).render(<App />);
+}


### PR DESCRIPTION
## Summary
- add React GUI placeholder
- expose `observable gui` command that launches a simple server

## Testing
- `yarn install` *(fails: couldn't reach network)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b3125862c8332b161e271b7e4fab7