### PR TITLE
Add runtime refresh on file changes

### DIFF
--- a/src/client/preview.js
+++ b/src/client/preview.js
@@ -5,6 +5,8 @@ import {enableCopyButtons} from "./pre.js";
 
 export * from "./index.js";
 
+globalThis.addEventListener("observablehq:fileupdate", () => runtime._compute());
+
 let minReopenDelay = 1000;
 let maxReopenDelay = 30000;
 let reopenDelay = minReopenDelay;

--- a/src/client/stdlib/fileAttachment.js
+++ b/src/client/stdlib/fileAttachment.js
@@ -1,13 +1,19 @@
 const files = new Map();
 
+function dispatchFileUpdate(name) {
+  globalThis.dispatchEvent(new CustomEvent("observablehq:fileupdate", {detail: name}));
+}
+
 export function registerFile(name, info, base = location) {
   const href = new URL(name, base).href;
   if (info == null) {
     files.delete(href);
+    dispatchFileUpdate(href);
   } else {
     const {path, mimeType, lastModified, size} = info;
     const file = new FileAttachmentImpl(new URL(path, base).href, name.split("/").pop(), mimeType, lastModified, size);
     files.set(href, file);
+    dispatchFileUpdate(href);
     return file;
   }
 }


### PR DESCRIPTION
## Summary
- dispatch a custom `observablehq:fileupdate` event when files are registered
- recompute runtime in preview when file updates occur

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683b4e9030b08332b186550c4c508b7d