### PR TITLE
Add interactive controls docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ npx @observablehq/framework gui
 
 By default this opens <http://127.0.0.1:3001/>.
 
+## Interactive controls
+
+Framework includes [Observable Inputs](docs/inputs/) for no-code UI. Sliders,
+dropdowns and other widgets let readers filter data interactively. See the
+[Interactive controls](docs/interactive-controls.md) guide for an example.
+
 ## Examples 🖼️
 
 https://github.com/observablehq/framework/tree/main/examples

--- a/docs/interactive-controls.md
+++ b/docs/interactive-controls.md
@@ -1,0 +1,39 @@
+---
+index: true
+---
+
+# Interactive controls
+
+Observable Framework exposes [Observable Inputs](https://github.com/observablehq/inputs) so you can add sliders, dropdowns and other widgets without writing custom code. These inputs let readers explore data dynamically, updating charts and tables as values change.
+
+The [No Code Transformation Doc](../No%20Code%20Transformation%20Doc) notes:
+
+> Key advantages: By building on Observable, you inherit its rich feature set: the reactive notebook environment, support for Observable Plot charts, and a library of interactive UI components ("Inputs" like sliders, dropdowns, etc.) for building dynamic controls.
+
+Below is a short example. A dropdown chooses a sport from a dataset, and a range slider filters athletes by weight.
+
+```js echo
+const sport = view(Inputs.select(
+  olympians.filter((d) => d.weight && d.height).map((d) => d.sport),
+  {sort: true, unique: true, label: "Sport"}
+));
+
+const weight = view(
+  Inputs.range(
+    d3.extent(olympians, (d) => d.weight),
+    {step: 1, label: "Weight (kg)"}
+  )
+);
+```
+
+```js echo
+Inputs.table(
+  olympians.filter(
+    (d) => d.sport === sport &&
+      d.weight < weight * 1.1 && weight * 0.9 < d.weight
+  ),
+  {sort: "weight"}
+)
+```
+
+See [Observable Inputs](./inputs/) for the full list of available widgets.

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -21,6 +21,7 @@ export default {
     {name: "Getting started", path: "/getting-started"},
     {name: "Deploying", path: "/deploying"},
     {name: "Embedding", path: "/embeds"},
+    {name: "Interactive controls", path: "/interactive-controls"},
     {
       name: "Reference",
       open: false,


### PR DESCRIPTION
## Summary
- document interactive controls using Observable Inputs
- link to new guide in README
- include page in docs navigation

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b4e388efc8332a7a46f95016c334a