### PR TITLE
Add drag-and-drop uploads and remote DB connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [**Observable Framework**](https://observablehq.com/framework/) is a free, [open-source](./LICENSE), static site generator for data apps, dashboards, reports, and more. Framework combines JavaScript on the front-end for interactive graphics with any language on the back-end for data analysis. Framework features [data loaders](https://observablehq.com/framework/loaders) that precompute static snapshots of data at build time for dashboards that load instantly.
 
+Recent additions include a drag-and-drop **dropzone** input for uploading files and a `RemoteDatabaseClient` for querying external databases over HTTP. These features simplify working with CSV or JSON data and connecting to remote sources without writing code.
+
 <a href="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/framework">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/framework/downloads-dark.svg">

--- a/docs/inputs/dropzone.md
+++ b/docs/inputs/dropzone.md
@@ -1,0 +1,17 @@
+# Dropzone input
+
+The dropzone input allows users to drag files onto a highlighted area. It exposes
+the dropped file in the same interface as [`FileAttachment`](../files), making it
+easy to parse CSV, JSON and other formats.
+
+```js echo
+const upload = view(Inputs.dropzone({label: "Upload CSV", accept: ".csv"}));
+```
+
+```js echo
+const table = await upload.csv({typed: true});
+```
+
+The dropzone also works when clicked, letting users select files via the native
+file picker. When a file is dragged over the zone, its appearance changes to
+offer visual feedback.

--- a/docs/inputs/index.md
+++ b/docs/inputs/index.md
@@ -126,5 +126,6 @@ For more, see the individual input pages:
 - [Date](./date) or [Datetime](./date) - choose a date
 - [Color](./color) - choose a color
 - [File](./file) - choose a local file
+- [Dropzone](./dropzone) - drag-and-drop file upload
 - [Search](./search) - query a tabular dataset
 - [Table](./table) - browse a tabular dataset

--- a/docs/lib/remote-db.md
+++ b/docs/lib/remote-db.md
@@ -1,0 +1,17 @@
+# RemoteDatabaseClient
+
+The `RemoteDatabaseClient` allows you to run SQL queries against a remote database
+via a simple HTTP POST API. Instantiate the client with the URL of an endpoint
+that accepts JSON requests of the form `{sql, params}` and returns query results
+as JSON.
+
+```js run=false
+import {RemoteDatabaseClient} from "observablehq:stdlib/remote-db";
+
+const db = new RemoteDatabaseClient("https://example.com/query");
+const rows = await db.sql`SELECT * FROM users WHERE id = ${id}`;
+```
+
+The endpoint should execute the provided SQL and return an array of result rows.
+This lightweight connector is useful for dashboards that need to query an
+existing database service without exposing credentials to the browser.

--- a/src/client/stdlib/inputs.css
+++ b/src/client/stdlib/inputs.css
@@ -280,3 +280,15 @@ form.__ns__-table {
 .__ns__-table tbody tr:first-child td {
   padding-top: 4px;
 }
+
+/* Drag-and-drop file input */
+.__ns__-dropzone {
+  border: 2px dashed var(--theme-foreground);
+  padding: var(--length3);
+  text-align: center;
+  cursor: pointer;
+}
+
+.__ns__-dropzone.__over {
+  background: var(--theme-background-alt);
+}

--- a/src/client/stdlib/inputs.js
+++ b/src/client/stdlib/inputs.js
@@ -58,3 +58,43 @@ class LocalFile extends AbstractFile {
     return this._.stream();
   }
 }
+
+export function dropzone(options = {}) {
+  const zone = document.createElement("div");
+  zone.className = "__ns__-dropzone";
+  zone.textContent = options.label ?? "Drop file";
+  const input = file(options);
+  input.style.display = "none";
+  zone.appendChild(input);
+  let value = null;
+
+  function setFiles(files) {
+    if (!files || files.length === 0) return;
+    value = options.multiple
+      ? Array.from(files, (f) => new LocalFile(f))
+      : new LocalFile(files[0]);
+    zone.dispatchEvent(new Event("input", {bubbles: true}));
+  }
+
+  input.addEventListener("input", () => {
+    value = input.value;
+    zone.dispatchEvent(new Event("input", {bubbles: true}));
+  });
+
+  zone.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    zone.classList.add("__over");
+  });
+
+  zone.addEventListener("dragleave", () => zone.classList.remove("__over"));
+  zone.addEventListener("drop", (event) => {
+    event.preventDefault();
+    zone.classList.remove("__over");
+    setFiles(event.dataTransfer?.files);
+  });
+
+  zone.addEventListener("click", () => input.click());
+
+  Object.defineProperty(zone, "value", {get: () => value});
+  return zone;
+}

--- a/src/client/stdlib/recommendedLibraries.js
+++ b/src/client/stdlib/recommendedLibraries.js
@@ -19,6 +19,7 @@ export const ReactDOM = () => import("npm:react-dom");
 export const sql = () => import("observablehq:stdlib/duckdb").then((duckdb) => duckdb.sql);
 export const SQLite = () => import("observablehq:stdlib/sqlite").then((sqlite) => sqlite.default);
 export const SQLiteDatabaseClient = () => import("observablehq:stdlib/sqlite").then((sqlite) => sqlite.SQLiteDatabaseClient); // prettier-ignore
+export const RemoteDatabaseClient = () => import("observablehq:stdlib/remote-db").then((db) => db.RemoteDatabaseClient); // prettier-ignore
 export const tex = () => import("observablehq:stdlib/tex").then((tex) => tex.default);
 export const topojson = () => import("npm:topojson-client");
 export const vg = () => import("observablehq:stdlib/vgplot").then((vg) => vg.default());

--- a/src/client/stdlib/remote-db.js
+++ b/src/client/stdlib/remote-db.js
@@ -1,0 +1,18 @@
+export class RemoteDatabaseClient {
+  constructor(endpoint) {
+    Object.defineProperty(this, "endpoint", {value: `${endpoint}`});
+  }
+  async query(sql, params) {
+    const response = await fetch(this.endpoint, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({sql, params})
+    });
+    if (!response.ok) throw new Error(`query failed: ${response.status}`);
+    return await response.json();
+  }
+  async sql(strings, ...values) {
+    const text = strings.join("?");
+    return this.query(text, values);
+  }
+}

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -33,6 +33,7 @@ export function getImplicitInputImports(inputs: Iterable<string>): Set<string> {
   if (set.has("mermaid")) implicits.add("npm:@observablehq/mermaid");
   if (set.has("Plot")) implicits.add("npm:@observablehq/plot");
   if (set.has("SQLite") || set.has("SQLiteDatabaseClient")) implicits.add("npm:@observablehq/sqlite");
+  if (set.has("RemoteDatabaseClient")) implicits.add("observablehq:stdlib/remote-db");
   if (set.has("tex")) implicits.add("npm:@observablehq/tex");
   if (set.has("topojson")) implicits.add("npm:topojson-client");
   if (set.has("vl")) implicits.add("observablehq:stdlib/vega-lite");

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -60,7 +60,9 @@ export const builtins = new Map<string, string>([
   ["npm:@observablehq/inputs", "/_observablehq/stdlib/inputs.js"], // TODO publish to npm
   ["npm:@observablehq/mermaid", "/_observablehq/stdlib/mermaid.js"], // TODO publish to npm
   ["npm:@observablehq/tex", "/_observablehq/stdlib/tex.js"], // TODO publish to npm
-  ["npm:@observablehq/sqlite", "/_observablehq/stdlib/sqlite.js"] // TODO publish to npm
+  ["npm:@observablehq/sqlite", "/_observablehq/stdlib/sqlite.js"], // TODO publish to npm
+  ["observablehq:stdlib/remote-db", "/_observablehq/stdlib/remote-db.js"],
+  ["npm:@observablehq/remote-db", "/_observablehq/stdlib/remote-db.js"]
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- add dropzone input for drag-and-drop file uploads
- support remote database queries via `RemoteDatabaseClient`
- document new input and connector
- expose new library in resolvers and recommended libraries
- mention new features in README

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b4e0241c48332898fca895868b288