### PR TITLE
Add bundled samples command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ npx @observablehq/framework gui
 
 By default this opens <http://127.0.0.1:3001/>.
 
+To explore the included sample datasets and a starter notebook, run:
+
+```sh
+npx @observablehq/framework samples
+```
+
+This copies the bundled files into a local `samples/` directory so you can preview them immediately.
+
 ## Examples 🖼️
 
 https://github.com/observablehq/framework/tree/main/examples

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/**/*.js",
     "dist/**/*.css",
-    "templates"
+    "templates",
+    "samples"
   ],
   "bin": {
     "observable": "dist/bin/observable.js"

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,8 @@
+# Sample Datasets and Templates
+
+This folder contains example data and a starter notebook that you can copy into a new project. The goal is to help new users explore Observable Framework without needing to supply their own data first.
+
+- **data/us-state-capitals.csv** – Small sample dataset of U.S. state capitals.
+- **sample-dashboard.md** – Simple notebook that plots the dataset using Observable Plot.
+
+You can copy these files into your project and run `observable preview` to experiment immediately.

--- a/samples/data/us-state-capitals.csv
+++ b/samples/data/us-state-capitals.csv
@@ -1,0 +1,51 @@
+name,description,latitude,longitude
+Alabama,Montgomery,32.377716,-86.300568
+Alaska,Juneau,58.301598,-134.420212
+Arizona,Phoenix,33.448143,-112.096962
+Arkansas,Little Rock,34.746613,-92.288986
+California,Sacramento,38.576668,-121.493629
+Colorado,Denver,39.739227,-104.984856
+Connecticut,Hartford,41.764046,-72.682198
+Delaware,Dover,39.157307,-75.519722
+Hawaii,Honolulu,21.307442,-157.857376
+Florida,Tallahassee,30.438118,-84.281296
+Georgia,Atlanta,33.749027,-84.388229
+Idaho,Boise,43.617775,-116.199722
+Illinois,Springfield,39.798363,-89.654961
+Indiana,Indianapolis,39.768623,-86.162643
+Iowa,Des Moines,41.591087,-93.603729
+Kansas,Topeka,39.048191,-95.677956
+Kentucky,Frankfort,38.186722,-84.875374
+Louisiana,Baton Rouge,30.457069,-91.187393
+Maine,Augusta,44.307167,-69.781693
+Maryland,Annapolis,38.978764,-76.490936
+Massachusetts,Boston,42.358162,-71.063698
+Michigan,Lansing,42.733635,-84.555328
+Minnesota,St. Paul,44.955097,-93.102211
+Mississippi,Jackson,32.303848,-90.182106
+Missouri,Jefferson City,38.579201,-92.172935
+Montana,Helena,46.585709,-112.018417
+Nebraska,Lincoln,40.808075,-96.699654
+Nevada,Carson City,39.163914,-119.766121
+New Hampshire,Concord,43.206898,-71.537994
+New Jersey,Trenton,40.220596,-74.769913
+New Mexico,Santa Fe,35.68224,-105.939728
+North Carolina,Raleigh,35.78043,-78.639099
+North Dakota,Bismarck,46.82085,-100.783318
+New York,Albany,42.652843,-73.757874
+Ohio,Columbus,39.961346,-82.999069
+Oklahoma,Oklahoma City,35.492207,-97.503342
+Oregon,Salem,44.938461,-123.030403
+Pennsylvania,Harrisburg,40.264378,-76.883598
+Rhode Island,Providence,41.830914,-71.414963
+South Carolina,Columbia,34.000343,-81.033211
+South Dakota,Pierre,44.367031,-100.346405
+Tennessee,Nashville,36.16581,-86.784241
+Texas,Austin,30.27467,-97.740349
+Utah,Salt Lake City,40.777477,-111.888237
+Vermont,Montpelier,44.262436,-72.580536
+Virginia,Richmond,37.538857,-77.43364
+Washington,Olympia,47.035805,-122.905014
+West Virginia,Charleston,38.336246,-81.612328
+Wisconsin,Madison,43.074684,-89.384445
+Wyoming,Cheyenne,41.140259,-104.820236

--- a/samples/sample-dashboard.md
+++ b/samples/sample-dashboard.md
@@ -1,0 +1,15 @@
+---
+title: Sample Dashboard
+---
+
+# Sample Dashboard
+
+This page uses a preloaded dataset of U.S. state capitals to render a scatter plot with Observable Plot.
+
+```js
+import * as Plot from "npm:@observablehq/plot";
+const capitals = FileAttachment("data/us-state-capitals.csv").csv({typed: true});
+Plot.plot({
+  marks: [Plot.dot(capitals, {x: "longitude", y: "latitude"})]
+})
+```

--- a/src/bin/observable.ts
+++ b/src/bin/observable.ts
@@ -67,7 +67,7 @@ else if (values.help) {
 
 /** Commands that use Clack formatting. When handling CliErrors, clack.outro()
  * will be used for these commands. */
-const CLACKIFIED_COMMANDS = ["create", "deploy", "login", "convert"];
+const CLACKIFIED_COMMANDS = ["create", "deploy", "login", "convert", "samples"];
 
 try {
   switch (command) {
@@ -85,6 +85,7 @@ try {
   deploy       deploy an app to Observable [deprecated]
   whoami       check authentication status
   convert      convert an Observable notebook to Markdown
+  samples      copy bundled sample datasets and notebooks
   help         print usage information
   version      print the version`
       );
@@ -108,6 +109,15 @@ try {
     case "create": {
       helpArgs(command, {});
       await import("../create.js").then(async (create) => create.create());
+      break;
+    }
+    case "samples": {
+      const {values} = helpArgs(command, {
+        options: {
+          dest: {type: "string", default: "samples", description: "output directory"}
+        }
+      });
+      await import("../samples.js").then(async (samples) => samples.copySamples(values.dest));
       break;
     }
     case "deploy": {

--- a/src/samples.ts
+++ b/src/samples.ts
@@ -1,0 +1,21 @@
+import {mkdir, copyFile, readdir, stat} from "node:fs/promises";
+import {basename, join} from "node:path/posix";
+import {fileURLToPath} from "node:url";
+
+async function recursiveCopy(src: string, dest: string): Promise<void> {
+  const st = await stat(src);
+  if (st.isDirectory()) {
+    await mkdir(dest, {recursive: true});
+    for (const entry of await readdir(src)) {
+      await recursiveCopy(join(src, entry), join(dest, entry));
+    }
+  } else {
+    await mkdir(join(dest, ".."), {recursive: true});
+    await copyFile(src, dest);
+  }
+}
+
+export async function copySamples(dest = "samples"): Promise<void> {
+  const source = join(fileURLToPath(import.meta.url), "..", "..", "samples");
+  await recursiveCopy(source, dest);
+}


### PR DESCRIPTION
## Summary
- bundle sample data and example notebook in `samples/`
- expose `samples` CLI command to copy bundled files
- document usage in README
- include samples in package files list

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b4f2a6ea8833281abb45bd13d5895