### PR TITLE
Add dataset upload and DB config UI

### DIFF
--- a/src/gui/App.tsx
+++ b/src/gui/App.tsx
@@ -1,18 +1,28 @@
 import React, {useEffect, useRef, useState} from "npm:react";
 import {Runtime, Inspector} from "npm:@observablehq/runtime";
 import * as Plot from "npm:@observablehq/plot";
+import {dropzone} from "../client/stdlib/inputs.js";
+import {RemoteDatabaseClient} from "../client/stdlib/remote-db.js";
 
 export default function App() {
   const chartRef = useRef<HTMLDivElement>(null);
+  const uploadRef = useRef<HTMLDivElement>(null);
   const [dataset, setDataset] = useState("aapl");
+  const [data, setData] = useState<any[]>(aapl);
   const [chartType, setChartType] = useState("line");
+  const [dbUrl, setDbUrl] = useState("");
+  const [sql, setSql] = useState("");
+
+  useEffect(() => {
+    setData(dataset === "aapl" ? aapl : cars);
+  }, [dataset]);
 
   useEffect(() => {
     if (!chartRef.current) return;
     const runtime = new Runtime();
     const main = runtime.module();
 
-    main.variable().define("data", dataset === "aapl" ? aapl : cars);
+    main.variable().define("data", data);
     main.variable().define("chartType", chartType);
     main
       .variable(Inspector.into(chartRef.current))
@@ -24,7 +34,43 @@ export default function App() {
       });
 
     return () => runtime.dispose();
-  }, [dataset, chartType]);
+  }, [data, chartType]);
+
+  // Initialize dropzone for file uploads
+  useEffect(() => {
+    if (!uploadRef.current) return;
+    const zone = dropzone({label: "Upload CSV or JSON", accept: ".csv,.json"});
+    const handle = async () => {
+      const file = zone.value;
+      if (!file) return;
+      try {
+        if (/\.csv$/i.test(file.name)) {
+          setData(await file.csv({typed: true}));
+        } else if (/\.json$/i.test(file.name)) {
+          setData(await file.json());
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    zone.addEventListener("input", handle);
+    uploadRef.current.appendChild(zone);
+    return () => {
+      zone.removeEventListener("input", handle);
+      uploadRef.current?.removeChild(zone);
+    };
+  }, []);
+
+  async function runQuery() {
+    if (!dbUrl || !sql) return;
+    try {
+      const db = new RemoteDatabaseClient(dbUrl);
+      const rows = await db.query(sql, []);
+      setData(rows);
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
   return (
     <div>
@@ -45,6 +91,38 @@ export default function App() {
           </select>
         </label>
       </div>
+
+      <div ref={uploadRef} style={{marginBottom: "1rem"}} />
+
+      <div style={{marginBottom: "1rem"}}>
+        <h2>Remote Database</h2>
+        <div>
+          <label>
+            Endpoint:
+            <input
+              type="text"
+              value={dbUrl}
+              onChange={(e) => setDbUrl(e.target.value)}
+              placeholder="https://example.com/query"
+            />
+          </label>
+        </div>
+        <div style={{marginTop: "0.5rem"}}>
+          <label>
+            SQL:
+            <textarea
+              value={sql}
+              onChange={(e) => setSql(e.target.value)}
+              rows={4}
+              cols={40}
+            />
+          </label>
+        </div>
+        <button style={{marginTop: "0.5rem"}} onClick={runQuery}>
+          Run Query
+        </button>
+      </div>
+
       <div ref={chartRef} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add dropzone file upload and RemoteDatabaseClient support in GUI

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `npm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b52ba6c6c83328227a1e0baac4f8d