### PR TITLE
Add GUI build/preview buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:prettier": "prettier --check src test",
     "test:tsc": "tsc --noEmit",
     "observable": "tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts",
+    "gui:electron": "electron ./dist/electron/main.js",
     "prepublishOnly": "yarn build"
   },
   "c8": {
@@ -132,6 +133,7 @@
     "prettier": "^3.0.3 <3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "electron": "^28.1.0",
     "rimraf": "^5.0.5",
     "tempy": "^3.1.0",
     "typescript": "^5.2.2 <5.6.0",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,0 +1,21 @@
+import {app, BrowserWindow} from 'electron';
+import {startGuiServer} from '../gui/server.js';
+
+let mainWindow: BrowserWindow | null = null;
+
+async function createWindow() {
+  await startGuiServer({hostname: '127.0.0.1', port: 3001, openBrowser: false});
+  mainWindow = new BrowserWindow({width: 1024, height: 768});
+  await mainWindow.loadURL('http://127.0.0.1:3001');
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/src/gui/App.tsx
+++ b/src/gui/App.tsx
@@ -6,6 +6,15 @@ export default function App() {
   const chartRef = useRef<HTMLDivElement>(null);
   const [dataset, setDataset] = useState("aapl");
   const [chartType, setChartType] = useState("line");
+  const [message, setMessage] = useState("");
+
+  async function trigger(path: string) {
+    const res = await fetch(path, {method: "POST"});
+    setMessage(await res.text());
+  }
+
+  const handleBuild = () => trigger("/api/build");
+  const handlePreview = () => trigger("/api/preview");
 
   useEffect(() => {
     if (!chartRef.current) return;
@@ -44,8 +53,15 @@ export default function App() {
             <option value="scatter">Scatter</option>
           </select>
         </label>
+        <button style={{marginLeft: "1rem"}} onClick={handleBuild}>
+          Build
+        </button>
+        <button style={{marginLeft: "0.5rem"}} onClick={handlePreview}>
+          Preview
+        </button>
       </div>
       <div ref={chartRef} />
+      {message && <p>{message}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow the GUI to trigger build and preview
- expose API endpoints to run the build and preview commands
- add Electron entry for desktop use
- add dev script for Electron and include Electron dependency

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b52e6ac18833288c42526a4d217e3