### PR TITLE
Add responsive GUI and Electron desktop target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Start the optional GUI editor with:
 npx @observablehq/framework gui
 ```
 
-By default this opens <http://127.0.0.1:3001/>.
+By default this opens <http://127.0.0.1:3001/>. The interface is responsive, so it adapts to mobile and desktop screens.
+
+To run the GUI as a desktop application, use:
+
+```sh
+npm run desktop
+```
 
 To explore the included sample datasets and a starter notebook, run:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,6 +153,10 @@ You can also launch the lightweight GUI editor:
 
 This opens <http://127.0.0.1:3001/> by default.
 
+The interface is responsive, so it works well on phones, tablets, and desktops. You can also package the GUI as an offline desktop app using Electron:
+
+<pre data-copy>npm run desktop</pre>
+
 You should see something like this:
 
 <pre data-copy="none"><b class="green">Observable Framework</b> v1.13.3

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "docs:build": "tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts build",
     "docs:deploy": "tsx --no-warnings=ExperimentalWarning ./src/bin/observable.ts deploy",
     "build": "rimraf dist && node build.js --outdir=dist --outbase=src \"src/**/*.{ts,tsx,js,jsx,css}\" --ignore \"**/*.d.ts\"",
+    "desktop": "npm run build && electron dist/gui/electron.js",
     "test": "concurrently npm:test:mocha npm:test:tsc npm:test:lint npm:test:prettier",
     "test:coverage": "c8 --check-coverage --lines 80 --per-file yarn test:mocha:all",
     "test:build": "rimraf test/build && rimraf --glob test/.observablehq/cache test/input/build/*/.observablehq/cache && cross-env npm_package_version=1.0.0-test node build.js --sourcemap --outdir=test/build \"{src,test}/**/*.{ts,tsx,js,jsx,css}\" --ignore \"test/input/**\" --ignore \"test/output/**\" --ignore \"test/preview/dashboard/**\" --ignore \"**/*.d.ts\" && cp -r templates test/build",
@@ -135,7 +136,8 @@
     "rimraf": "^5.0.5",
     "tempy": "^3.1.0",
     "typescript": "^5.2.2 <5.6.0",
-    "undici": "^6.7.1"
+    "undici": "^6.7.1",
+    "electron": "^27.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/src/gui/App.tsx
+++ b/src/gui/App.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from "npm:react";
 import {Runtime, Inspector} from "npm:@observablehq/runtime";
 import * as Plot from "npm:@observablehq/plot";
+import "./app.css";
 
 export default function App() {
   const chartRef = useRef<HTMLDivElement>(null);
@@ -27,9 +28,9 @@ export default function App() {
   }, [dataset, chartType]);
 
   return (
-    <div>
+    <div id="root">
       <h1>Observable GUI</h1>
-      <div style={{marginBottom: "1rem"}}>
+      <div className="controls">
         <label>
           Dataset:
           <select value={dataset} onChange={(e) => setDataset(e.target.value)}>
@@ -37,7 +38,7 @@ export default function App() {
             <option value="cars">Cars</option>
           </select>
         </label>
-        <label style={{marginLeft: "1rem"}}>
+        <label>
           Chart Type:
           <select value={chartType} onChange={(e) => setChartType(e.target.value)}>
             <option value="line">Line</option>
@@ -45,7 +46,7 @@ export default function App() {
           </select>
         </label>
       </div>
-      <div ref={chartRef} />
+      <div ref={chartRef} className="chart" />
     </div>
   );
 }

--- a/src/gui/app.css
+++ b/src/gui/app.css
@@ -1,0 +1,17 @@
+#root {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.chart {
+  width: 100%;
+}

--- a/src/gui/electron.ts
+++ b/src/gui/electron.ts
@@ -1,0 +1,22 @@
+import {app, BrowserWindow} from 'electron';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+function createWindow() {
+  const root = dirname(fileURLToPath(import.meta.url));
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+  win.loadFile(join(root, 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Observable GUI</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add responsive styles and meta viewport
- import CSS in React GUI and adjust layout
- add Electron main process script and build target
- expose `npm run desktop` script and add Electron dependency
- document responsive design and desktop build in README and Getting Started guide

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683b52f928dc83328a805d791bc7f1de