### PR TITLE
Add setup script for dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ npx @observablehq/framework samples
 
 This copies the bundled files into a local `samples/` directory so you can preview them immediately.
 
+## Development setup
+
+To install dependencies for local development, run the included setup script. It
+verifies that Node.js and Yarn are available and then installs all packages via
+Yarn:
+
+```sh
+./setup.sh
+```
+
 ## Examples 🖼️
 
 https://github.com/observablehq/framework/tree/main/examples

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-If you’d like to contribute to Observable Framework, here’s how. First clone the [git repo](https://github.com/observablehq/framework) and run [Yarn Classic](https://classic.yarnpkg.com/lang/en/docs/install/) to install dependencies:
+If you’d like to contribute to Observable Framework, here’s how. First clone the [git repo](https://github.com/observablehq/framework) and run the provided setup script to install dependencies:
 
 ```sh
 git clone git@github.com:observablehq/framework.git
 cd framework
-yarn
+./setup.sh
 ```
 
 Next start the local preview server:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script installs development dependencies for Observable Framework.
+# It verifies Node.js >=18 and ensures Yarn is available via Corepack.
+
+if ! command -v node >/dev/null; then
+  echo "Error: Node.js is not installed. Please install Node.js 18 or later." >&2
+  exit 1
+fi
+
+NODE_MAJOR=$(node --version | sed -E 's/v([0-9]+).*/\1/')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "Error: Node.js 18 or later is required. Found $(node --version)." >&2
+  exit 1
+fi
+
+# Ensure yarn is available
+if ! command -v yarn >/dev/null; then
+  echo "Yarn not found; enabling via corepack." >&2
+  corepack enable
+fi
+
+echo "Installing dependencies via Yarn..."
+yarn install
+
+echo "Setup complete." 


### PR DESCRIPTION
## Summary
- provide a `setup.sh` helper to check for Node.js and Yarn and run `yarn install`
- document using the setup script in the README
- update contributing instructions to use the script

## Testing
- `./setup.sh` *(fails: RequestError 403)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684c37ba5b2083329808876f1f2a6d68